### PR TITLE
Fix a CMake compilation warning about GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ cmake_policy(SET CMP0042 NEW)
 # Only interpret if() arguments when unquoted
 cmake_policy(SET CMP0054 NEW)
 
+enable_language(C)
+
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 


### PR DESCRIPTION
`enable_language(C)` needs to be called before GNUInstallDirs is included.

Fixes #29