### PR TITLE
Break the build on CMake warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       - cmake --build . --config Release
       - cmake --install . --config Release
       - cd ..
-    script: cmake .. -DCMocka_DIR="$PWD/../libinstall/lib/cmake/cmocka" && cmake --build . --verbose --config Debug && cp "$PWD/../libinstall/bin/cmocka.dll" "$PWD/libcatoolbox/Debug/cmocka.dll" && ctest
+    script: cmake -Werror=dev -Werror=deprecated .. -DCMocka_DIR="$PWD/../libinstall/lib/cmake/cmocka" && cmake --build . --config Debug && cp "$PWD/../libinstall/bin/cmocka.dll" "$PWD/libcatoolbox/Debug/cmocka.dll" && ctest
   - os: osx
     install:
       - brew install cmocka
@@ -47,4 +47,4 @@ addons:
 before_script:
   - mkdir build
   - cd build
-script: cmake .. && cmake --build . && ctest
+script: cmake -Werror=dev -Werror=deprecated .. && cmake --build . && ctest


### PR DESCRIPTION
Break the build if any CMake developer or deprecation warnings are issued.

Fixes #34