### PR TITLE
Windows tests: copy all target dependencies to the target folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       - cmake --build . --config Release
       - cmake --install . --config Release
       - cd ..
-    script: cmake -Werror=dev -Werror=deprecated .. -DCMocka_DIR="$PWD/../libinstall/lib/cmake/cmocka" && cmake --build . --config Debug && cp "$PWD/../libinstall/bin/cmocka.dll" "$PWD/libcatoolbox/Debug/cmocka.dll" && ctest
+    script: cmake -Werror=dev -Werror=deprecated .. -DCMocka_DIR="$PWD/../libinstall/lib/cmake/cmocka" && cmake --build . --config Debug && ctest
   - os: osx
     install:
       - brew install cmocka

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,12 +35,17 @@
 
 # On Mac OS X systems, we need to differentiate between the Apple Clang
 # variant and the standard Clang variant, as they support different flags.
-# For this reason, require CMake to be version 3.0 or higher on that OS
+# For this reason, require CMake to be version 3.0 or higher on that OS.
+# On Microsoft Windows, we require CMake 3.16 or higher to be able to
+# dynamically detect DLL dependencies and copy them to the target directory at
+# build time (this is required by unit tests).
 if(APPLE)
     cmake_minimum_required(VERSION 3.0.0)
-else(APPLE)
+elseif(WIN32)
+    cmake_minimum_required(VERSION 3.16.0)
+else()
     cmake_minimum_required(VERSION 2.8.12)
-endif(APPLE)
+endif()
 
 # Report the Apple Clang compiler as AppleClang
 cmake_policy(SET CMP0025 NEW)
@@ -116,6 +121,16 @@ if(CATOOLBOX_RUN_TESTS)
     endif(NOT (DEFINED CMOCKA_INCLUDE_DIR AND DEFINED CMOCKA_LIBRARIES))
     enable_testing()
 endif(CATOOLBOX_RUN_TESTS)
+# Since the CMocka configuration file does not offer us a variable containing
+# the full path to the library, we need to ask for it on Microsoft Windows.
+# By default, we will try to find the binary library in
+# ${CMocka_DIR}/../../../bin.
+if(WIN32)
+    set(CATOOLBOX_CMOCKA_BINARY_DIR "${CMocka_DIR}/../../../bin" CACHE PATH "The path to the directory where the CMocka binary files are installed.")
+    if(NOT (EXISTS "${CATOOLBOX_CMOCKA_BINARY_DIR}/cmocka.dll"))
+        message(FATAL_ERROR "cmocka.dll was not found in '${CATOOLBOX_CMOCKA_BINARY_DIR}'.")
+    endif(NOT (EXISTS "${CATOOLBOX_CMOCKA_BINARY_DIR}/cmocka.dll"))
+endif(WIN32)
 
 set(CATOOLBOX_CMAKE_CONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/CAToolbox${CATOOLBOX_VERSION_SUFFIX}")
 

--- a/cmake/CopyDependencyForTarget.cmake
+++ b/cmake/CopyDependencyForTarget.cmake
@@ -1,0 +1,93 @@
+# Copyright © 2019-2020, the catoolbox contributors
+#
+# This file is free software: you can redistribute it and/or modify it under:
+# - the terms of the GNU Lesser General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version; and/or
+# - the terms of the GNU General Public License as published by the Free
+#   Software Foundation, either version 3 of the License, or (at your option)
+#   any later version.
+# If you modify this file, you may:
+# - dual license your modifications under both sets of terms, or
+# - license them under one of those sets of terms. In this case, remove the
+#   set of terms you do not wish to license your modifications under from your
+#   version.
+#
+# This file is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License and of the
+# GNU Lesser General Public License along with catoolbox. If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# Additional permission under GNU GPL version 3 section 7
+#
+# If you modify this file by linking or combining it with
+# - OpenSSL (or a modified version of that library), or
+# - any C/C++ runtime library,
+# containing parts covered by the terms of their respective licenses, the
+# licensors of this file grant you additional permission to convey the
+# resulting work.
+# If you modify this software, you may extend this exception to your version of
+# the software, but you are not obliged to do so. If you do not wish to do so,
+# delete this exception statement from your version.
+
+# This script is run to get the dependencies of an executable file and to
+# copy them to the target directory (useful for Windows builds where we have
+# no RPATH equivalent).
+
+if(${CMAKE_VERSION} VERSION_LESS "3.16.0")
+    message(FATAL_ERROR "CMake 3.16.0 or later is required to run this script.")
+endif(${CMAKE_VERSION} VERSION_LESS "3.16.0")
+if(NOT DEFINED CATOOLBOX_EXCLUSIONS)
+    message(FATAL_ERROR "You must define the catoolbox exclusion list.")
+endif(NOT DEFINED CATOOLBOX_EXCLUSIONS)
+if(NOT DEFINED TARGET_TO_TRACK)
+    message(FATAL_ERROR "You must define a target to track.")
+endif(NOT DEFINED TARGET_TO_TRACK)
+if(NOT DEFINED TARGET_ADDITIONAL_DIRECTORIES)
+    set(TARGET_ADDITIONAL_DIRECTORIES "")
+endif(NOT DEFINED TARGET_ADDITIONAL_DIRECTORIES)
+if(NOT DEFINED TARGET_FILE_DIR)
+    message(FATAL_ERROR "You must define the target directory.")
+endif(NOT DEFINED TARGET_FILE_DIR)
+string(TOLOWER "${CATOOLBOX_EXCLUSIONS}" CATOOLBOX_EXCLUSIONS_LOWER)
+string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" CATOOLBOX_EXCLUSIONS_ESCAPED
+       "${CATOOLBOX_EXCLUSIONS_LOWER}")
+list(TRANSFORM CATOOLBOX_EXCLUSIONS_ESCAPED PREPEND "^")
+list(TRANSFORM CATOOLBOX_EXCLUSIONS_ESCAPED APPEND "$")
+file(GET_RUNTIME_DEPENDENCIES
+     RESOLVED_DEPENDENCIES_VAR executable_deps
+     EXECUTABLES "${TARGET_TO_TRACK}"
+     DIRECTORIES "${TARGET_ADDITIONAL_DIRECTORIES}"
+     PRE_EXCLUDE_REGEXES
+        "^advapi32\\.dll$"
+        "^comctl32\\.dll$"
+        "^comdlg32\\.dll$"
+        "^gdi32\\.dll$"
+        "^imm32\\.dll$"
+        "^kernel32\\.dll$"
+        "^netapi32\\.dll$"
+        "^ole32\\.dll$"
+        "^shell32\\.dll$"
+        "^shscrap\\.dll$"
+        "^user32\\.dll$"
+        "^winmm\\.dll$"
+        "^ws2_32\\.dll$"
+        "^msvcrt.*\\.dll$"
+        "^msvcp.*\\.dll$"
+        "^crtdll.*\\.dll$"
+        "^atl.*\\.dll$"
+        "^mfc.*\\.dll$"
+        "^vcomp.*\\.dll$"
+        "^vcruntime.*\\.dll$"
+        "^ucrtbase.*\\.dll$"
+        "^api\\-ms\\-win\\-.*\\.dll$"
+        ${CATOOLBOX_EXCLUSIONS_ESCAPED})
+if(executable_deps)
+    message(STATUS "${TARGET_TO_TRACK}: copying \"${executable_deps}\" to "
+                   "\"${TARGET_FILE_DIR}\"")
+    file(COPY ${executable_deps}
+         DESTINATION "${TARGET_FILE_DIR}")
+endif(executable_deps)

--- a/cmake/Modules/AddCAToolboxTest.cmake
+++ b/cmake/Modules/AddCAToolboxTest.cmake
@@ -52,4 +52,18 @@ function(add_catoolbox_test target)
             ${CMOCKA_INCLUDE_DIR}
     )
     add_test(${target} "test_${target}")
+    if(WIN32)
+        # Ensure that any dependencies of the test target (e.g. the CMocka DLL)
+        # are copied to the destination directory. Requires CMake 3.16+.
+        # Note that, since the CMocka configuration files do not provide us
+        # with a variable exposing the full path to the binary, we need to
+        # add its path explicitly.
+        add_custom_command(TARGET "test_${target}" POST_BUILD
+                           COMMAND ${CMAKE_COMMAND}
+                               -D CATOOLBOX_EXCLUSIONS="$<TARGET_FILE_NAME:libcatoolbox>"
+                               -D TARGET_TO_TRACK="$<TARGET_FILE:test_${target}>"
+                               -D TARGET_ADDITIONAL_DIRECTORIES="${CATOOLBOX_CMOCKA_BINARY_DIR}"
+                               -D TARGET_FILE_DIR="$<TARGET_FILE_DIR:test_${target}>"
+                               -P "${PROJECT_SOURCE_DIR}/cmake/CopyDependencyForTarget.cmake")
+    endif(WIN32)
 endfunction(add_catoolbox_test)


### PR DESCRIPTION
Copy target dependencies to the target folder. This allows tests to run correctly on Windows (the CMocka library is now located into the same directory of the test executables as a result).